### PR TITLE
Add Windows signature for CTFPlayer::GetEntityForLoadoutSlot

### DIFF
--- a/addons/sourcemod/gamedata/tf2.wearables.txt
+++ b/addons/sourcemod/gamedata/tf2.wearables.txt
@@ -31,7 +31,7 @@
 			"CTFPlayer::GetEntityForLoadoutSlot"
 			{
 				"library"	"server"
-				"windows"	""
+				"windows"	"\x55\x8b\xec\x51\x53\x8b\x5d\x2a\x57\x8b\xf9\x89\x7d\x2a\x83\xfb\x07\x74\x2a\x83\xfb\x08\x74\x2a\x83\xfb\x09\x74\x2a\x83\xfb\x0a\x74\x2a"
 				"linux"		"@_ZN9CTFPlayer23GetEntityForLoadoutSlotEi"
 				"mac"		"@_ZN9CTFPlayer23GetEntityForLoadoutSlotEi"
 			}


### PR DESCRIPTION
In the 20150828 version of server.dll, the function is located at offset 48a4f0/1048b0f0.

I've tested this and it works.
