### PR TITLE
Maintenance and support for bool parameter in CTFPlayer::GetEntityForLoadoutSlot

### DIFF
--- a/addons/sourcemod/gamedata/tf2.wearables.txt
+++ b/addons/sourcemod/gamedata/tf2.wearables.txt
@@ -6,16 +6,16 @@
 		{
 			"CTFPlayer::EquipWearable"
 			{
-				"windows"	"426"
-				"linux"		"427"
-				"mac"		"427"
+				"windows"	"430"
+				"linux"		"431"
+				"mac"		"431"
 			}
 
 			"CTFPlayer::RemoveWearable"
 			{
-				"windows"	"427"
-				"linux"		"428"
-				"mac"		"428"
+				"windows"	"431"
+				"linux"		"432"
+				"mac"		"432"
 			}
 
 			"CBaseEntity::IsWearable"
@@ -30,10 +30,11 @@
 		{
 			"CTFPlayer::GetEntityForLoadoutSlot"
 			{
+				// called a few blocks after function with unique x-ref string "enable_misc2_noisemaker"
 				"library"	"server"
 				"windows"	"\x55\x8b\xec\x51\x53\x8b\x5d\x2a\x57\x8b\xf9\x89\x7d\x2a\x83\xfb\x07\x74\x2a\x83\xfb\x08\x74\x2a\x83\xfb\x09\x74\x2a\x83\xfb\x0a\x74\x2a"
-				"linux"		"@_ZN9CTFPlayer23GetEntityForLoadoutSlotEi"
-				"mac"		"@_ZN9CTFPlayer23GetEntityForLoadoutSlotEi"
+				"linux"		"@_ZN9CTFPlayer23GetEntityForLoadoutSlotEib"
+				"mac"		"@_ZN9CTFPlayer23GetEntityForLoadoutSlotEib"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/include/tf2wearables.inc
+++ b/addons/sourcemod/scripting/include/tf2wearables.inc
@@ -109,9 +109,10 @@ native bool:TF2_IsWearable(entity);
  * 
  * @param client		Client whose item we want
  * @param slot		The slot whose item we want
- * @return entity		Entity index or -1 if no item found
+ * @param include_wearable_weapons		False if wearable items in weapon slots should be ignored
+ * @return entity		Entity index; -1 if no item found or if slot contains wearable and include_wearable_weapons is false
  */
-native TF2_GetPlayerLoadoutSlot(client, TF2LoadoutSlot:slot);
+native TF2_GetPlayerLoadoutSlot(client, TF2LoadoutSlot:slot, bool:include_wearable_weapons = true);
 
 /**
  * Removes all non-Taunt wearables from a client

--- a/addons/sourcemod/scripting/tf2wearables.sp
+++ b/addons/sourcemod/scripting/tf2wearables.sp
@@ -97,6 +97,7 @@ public OnPluginStart()
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CTFPlayer::GetEntityForLoadoutSlot");
 	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_AddParameter(SDKType_Bool, SDKPass_Plain);
 	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
 	hGetEntFromSlot = EndPrepSDKCall();
 }
@@ -167,6 +168,7 @@ public Native_GetLoadoutSlot(Handle:plugin, numParams)
 	}
 	
 	new TF2LoadoutSlot:slot = GetNativeCell(2);
+	new check_wearable = numParams < 3? true : GetNativeCell(3);
 	
-	return SDKCall(hGetEntFromSlot, client, slot);
+	return SDKCall(hGetEntFromSlot, client, slot, check_wearable);
 }


### PR DESCRIPTION
PR does a few things:

* Update vtable offsets for the latest TF2 build
* Adds support for the new parameter in 'CTFPlayer::GetEntityForLoadoutSlot()' (wearable entities in weapon slots are not returned if the parameter is set to `false`); by default this is set to `true`.